### PR TITLE
Ensure internal links are generated relative

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,7 +9,7 @@
             {{ .Date.Format (.Site.Params.dateForm | default "Mon Jan 02, 2006")}} --
 
             {{ end }}
-            <a href="{{.Permalink}}">
+            <a href="{{.RelPermalink}}">
                 {{.Title}}
             </a>
         </li>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -19,7 +19,7 @@
             {{ else }}
                 {{ range .Site.Sections }}
                     <div class="big-link"> 
-                        <a href="{{.Permalink}}">
+                        <a href="{{.RelPermalink}}">
                             {{.Title}}
                         </a>
                     </div>

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -1,16 +1,16 @@
 {{ define "section_content" }}
 <div class="section" id="content">
     {{ .Date.Format (.Site.Params.dateForm | default "Mon Jan 02, 2006") }} &#183; {{ .WordCount }} words
-    {{ with .Params.tags }}
+    {{ range $term := .Params.tags }}
+    {{ with $.Site.GetPage (printf "/%s/%s" "tags" $term | urlize) }}
     <div class="tag-container">
-        {{ range . }}
         <span class="tag">
-            <a href="{{ "tags/" | absURL }}{{ . | urlize }}">
-                {{.}}
+            <a href="{{ .RelPermalink }}">
+                {{ $term }}
             </a>
         </span>
-        {{ end }}
     </div>
+    {{ end }}
     {{ end }}
     <hr/>
     {{ .Content }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -1,17 +1,17 @@
 {{ define "section_content" }}
 <div class="section" id="content">
     {{ .Date.Format (.Site.Params.dateForm | default "Mon Jan 02, 2006") }} &#183; {{ .WordCount }} words
-    {{ range $term := .Params.tags }}
-    {{ with $.Site.GetPage (printf "/%s/%s" "tags" $term | urlize) }}
     <div class="tag-container">
+        {{ range $term := .Params.tags }}
+        {{ with $.Site.GetPage (printf "/%s/%s" "tags" $term | urlize) }}
         <span class="tag">
             <a href="{{ .RelPermalink }}">
                 {{ $term }}
             </a>
         </span>
+        {{ end }}
+        {{ end }}
     </div>
-    {{ end }}
-    {{ end }}
     <hr/>
     {{ .Content }}
 </div>


### PR DESCRIPTION
First off thanks for this lovely theme 👍 

When building my own blog using this theme I noticed `htmlproofer` started reporting some missing external links, like below:

```
- ./public/posts/circleci-workspaces/index.html
  *  External link https://sambriggs.dev/tags/circleci failed: 404 No error
  *  internally linking to /the-birth-of-a-blog.md, which does not exist (line 0)
     <a href="/the-birth-of-a-blog.md">first post</a>
- ./public/tags/circleci/index.html
  *  External link https://sambriggs.dev/posts/circleci-workspaces/ failed: 404 No error
- ./public/tags/index.html
  *  External link https://sambriggs.dev/tags/circleci/ failed: 404 No error
```

It turns out there are still some places in the theme that use `.Permalink` rather than `.RelPermalink`.

Futhermore, it looks like the manual building of tag URLs [can be replaced](https://discourse.gohugo.io/t/how-to-get-permalink-of-taxonomies-in-templates/12927/15) by using `.GetPage` to get Hugo to supply the `.RelPermalink` of a taxonomy term page.

Hopefully you find this PR useful. 

Thanks again 😄 