### PR TITLE
Change "grid-auto-rows: 400px" -> "grid-auto-rows: auto"

### DIFF
--- a/assets/sass/_elements.sass
+++ b/assets/sass/_elements.sass
@@ -110,7 +110,7 @@ article
     display: grid
     grid-gap: 20px
     grid-template-columns: repeat(auto-fit, minmax(400px, 1fr))
-    grid-auto-rows: 400px
+    grid-auto-rows: auto
     @media screen and (max-width: 736px)
         grid-template-columns: repeat(auto-fit, minmax(100%, 1fr))
 


### PR DESCRIPTION
Hi there, thank you for this theme! I noticed that in gallery view, photos are be cropped to fit the max. height of their containing row (in this case 400px). This comes down to personal taste, but I'd prefer to see the whole photo every time, which this one-liner does quite nicely.