### PR TITLE
minifying and fingerprinting custom css files

### DIFF
--- a/layouts/partials/head/css.html
+++ b/layouts/partials/head/css.html
@@ -12,10 +12,18 @@
 {{ end }}
 
 <!-- Custom css -->
-{{ range .Site.Params.customCSS -}}
-{{ $style := resources.Get . }}
-<link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous" media="screen">
-{{- end }}
+{{ if .Site.IsServer }}
+  {{ range .Site.Params.customCSS -}}
+    {{ $style := resources.Get . }}
+      <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous" media="screen">
+  {{- end }}
+{{ else }}
+  {{ range .Site.Params.customCSS -}}
+    {{ $style := resources.Get . }}
+    {{ $bundle := $style | minify | fingerprint }}
+    <link rel="stylesheet" href="{{ $bundle.RelPermalink }}" integrity="{{ $bundle.Data.Integrity }}" crossorigin="anonymous" media="screen">
+  {{- end }}
+{{ end }}
 
 <!-- PhotoSwipe -->
 {{ if eq .Type "gallery" }}


### PR DESCRIPTION
Just a little improvement to the customCSS feature. It's like a torture to me when I have to wait for a cache expiration in order to see my changes live, so it's important to fingerprint the assets.

I decided not to run the autoprefixer here because sometimes the user wants full control over CSS configurations. What do you think @victoriadrake ?