### PR TITLE
Make theme available as Hugo module

### DIFF
--- a/go. mod
+++ b/go. mod
@@ -1,0 +1,3 @@
+module github.com/victoriadrake/hugo-theme-sam
+
+go 1.12


### PR DESCRIPTION
This PR adds a `go.mod` file to make this Theme available as a [Hugo module](https://gohugo.io/hugo-modules/). This change is fully backwards compatible - the theme can still be used without Hugo modules as before.