### PR TITLE
Caption support for the gallery

### DIFF
--- a/assets/js/gallery.js
+++ b/assets/js/gallery.js
@@ -4,6 +4,7 @@ const Gallery = (selector) => {
       const link = div.children[0];
       const size = link.getAttribute("data-size").split("x");
       const img = link.children[0];
+      const caption = img.dataset.caption;
 
       return {
         div,
@@ -11,6 +12,7 @@ const Gallery = (selector) => {
         w: parseInt(size[0], 10),
         h: parseInt(size[1], 10),
         msrc: img.getAttribute("src"),
+        title: caption,
       };
     });
   };

--- a/layouts/gallery/list.html
+++ b/layouts/gallery/list.html
@@ -11,7 +11,7 @@
         {{ $resized := $element.Resize $.Params.maxWidth }}
         <div>
             <a href="{{ $element.RelPermalink }}" data-size="{{ $element.Width }}x{{ $element.Height }}">
-                <img src="{{ $resized.RelPermalink }}" alt="{{ $element.Name }}" data-index="{{ $index }}"/>
+                <img src="{{ $resized.RelPermalink }}" alt="{{ $element.Name }}" data-index="{{ $index }}" data-caption="{{ .Params.caption }}"/>
             </a>
         </div>
     {{ end }}


### PR DESCRIPTION
Hi!

My proposal is to add a caption support for the gallery.

This will need a change also in how the content is structured so, in the vein of hugo page resources, images should be listed in the frontmatter like this:

```yaml
---
title: my post
resources:
  - src: first.jpg
    params:
      caption: my caption
---
```

What do you think?